### PR TITLE
FIX: 꽃가루 정보를 입력해도 미세먼지가 출력되는 문제

### DIFF
--- a/backend/weatherAdviceRouter.js
+++ b/backend/weatherAdviceRouter.js
@@ -14,6 +14,8 @@ function isAirQualityRelated(text) {
 async function handleAirAdvice({ lat, lon, locationName }, res) {
   const air = await getAirQuality(lat, lon);
   const pollen = await getPollenAmbee(lat, lon);
+  
+  try {
 
   if (!air && !pollen) {
     return res.json({ reply: '죄송해요. 공기질과 꽃가루 정보를 불러오지 못했어요.' });
@@ -42,8 +44,6 @@ ${parts.join('\n')}
 `;
 
   const contents = [...conversationStore.getHistory(), { role: 'user', parts: [{ text: prompt }] }];
-
-  try {
     const result = await axios.post(
       `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`,
       { contents }
@@ -66,7 +66,7 @@ ${parts.join('\n')}
 
 //우산에 대한 답변
 function isUmbrellaRelated(text) {
-  const keywords = ['우산', '비', '비올까', '소나기', '강수확률', 'rain', 'umbrella'];
+  const keywords = ['우산', '비', '비올까', '소나기', '강수확률', 'rain', 'umbrella', '강수량', '강수'];
   return keywords.some(kw => text.includes(kw));
 }
 


### PR DESCRIPTION
# 요약
`꽃가루 어때` , `미세먼지 어때` 와 같이 물어보면 꽃가루와 미세먼지 정보를 한 번에 출력해야 하는데, 미세먼지 정보만 출력하는 문제가 있었음.

# 작업 내용
![image](https://github.com/user-attachments/assets/0820e108-fd90-4b5e-bdd7-568732281ce7)
1. `weatherAdviceRouter.js` 파일의 `handleAirAdvice` 에서, `try` 가 잘못된 위치에서 실행되고 있어 꽃가루 정보를 출력에 포함하지 못하고 있었음. → 위치를 변경하여 해결

# 참고사항
- `isUmbrellaRelated`에서 키워드 '강수량', '강수’ 를 추가하였음.